### PR TITLE
Revert sphinx 2.3 change, allow MVA sorting

### DIFF
--- a/src/sphinxsort.cpp
+++ b/src/sphinxsort.cpp
@@ -3856,17 +3856,6 @@ ESortClauseParseResult sphParseSortClause ( const CSphQuery * pQuery, const char
 			// try to lookup plain attr in sorter schema
 			int iAttr = tSchema.GetAttrIndex ( pTok );
 
-			// do not order by mva (the result is undefined)			
-			if ( iAttr>=0 )
-			{
-				ESphAttr eAttrType = tSchema.GetAttr(iAttr).m_eAttrType;
-				if ( eAttrType==SPH_ATTR_UINT32SET || eAttrType==SPH_ATTR_INT64SET || eAttrType==SPH_ATTR_UINT32SET_PTR || eAttrType==SPH_ATTR_INT64SET_PTR )
-				{
-					sError.SetSprintf ( "order by MVA is undefined" );
-					return SORT_CLAUSE_ERROR;
-				}
-			}
-
 			// try to lookup aliased count(*) and aliased groupby() in select items
 			if ( iAttr<0 )
 			{


### PR DESCRIPTION
MVAs sometimes only contain one value per document and are used to make indexer more performant. In these cases, it should be safe to sort.

Related change: https://github.com/sphinxsearch/sphinx/commit/6ba73cab46a7c81563422092a9cddf356e87bdff#diff-23c967feea83c5c28cd6ca3b3d700af9

Related issue: http://sphinxsearch.com/bugs/print_bug_page.php?bug_id=2209
